### PR TITLE
Use SSL connection for QQ Mail

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ Here are all the variables you need to set:
 | ZOTERO_KEY |  str  | An Zotero API key with read access. Get a key from [here](https://www.zotero.org/settings/security).  | AB5tZ877P2j7Sm2Mragq041H   |
 | ARXIV_QUERY | str  | The search query for retrieving arxiv papers. Refer to the [official document](https://info.arxiv.org/help/api/user-manual.html#query_details) for details. The example queries papers about AI, CV, NLP, ML. Find the abbr of your research area from [here](https://arxiv.org/category_taxonomy).  | cat:cs.AI OR cat:cs.CV OR cat:cs.LG OR cat:cs.CL |
 | SMTP_SERVER | str | The SMTP server that sends the email. I recommend to utilize a seldom-used email for this. Ask your email provider (Gmail, QQ, Outlook, ...) for its SMTP server| smtp.qq.com |
-| SMTP_PORT | int | The port of SMTP server. | 25 |
+| SMTP_PORT | int | The port of SMTP server. | 25 **QQ should use port 465. An error occurs for the port 587**|
 | SENDER | str | The email account of the SMTP server that sends you email. | abc@qq.com |
 | SENDER_PASSWORD | str | The password of the sender account. Note that it's not necessarily the password for logging in the e-mail client, but the authentication code for SMTP service. Ask your email provider for this.   | abcdefghijklmn |
 | RECEIVER | str | The e-mail address that receives the paper list. | abc@outlook.com |

--- a/main.py
+++ b/main.py
@@ -106,7 +106,10 @@ def send_email(sender:str, receiver:str, password:str,smtp_server:str,smtp_port:
     today = datetime.datetime.now().strftime('%Y/%m/%d')
     msg['Subject'] = Header(f'Daily arXiv {today}', 'utf-8').encode()
 
-    server = smtplib.SMTP(smtp_server, smtp_port)
+    if smtp_server == 'smtp.qq.com':
+        server = smtplib.SMTP_SSL(smtp_server, smtp_port)
+    else:
+        server = smtplib.SMTP(smtp_server, smtp_port)
     server.starttls()
     server.login(sender, password)
     server.sendmail(sender, [receiver], msg.as_string())

--- a/main.py
+++ b/main.py
@@ -110,7 +110,7 @@ def send_email(sender:str, receiver:str, password:str,smtp_server:str,smtp_port:
         server = smtplib.SMTP_SSL(smtp_server, smtp_port)
     else:
         server = smtplib.SMTP(smtp_server, smtp_port)
-    server.starttls()
+        server.starttls()
     server.login(sender, password)
     server.sendmail(sender, [receiver], msg.as_string())
     server.quit()


### PR DESCRIPTION
QQ Mail server only accepts SSL connections. This is to fix the bug that the connection will fail when the sender is smtp.qq.com.