### PR TITLE
Fix: remove extra spaces in path joining for ZOTERO_IGNORE matching

### DIFF
--- a/main.py
+++ b/main.py
@@ -24,7 +24,7 @@ def get_zotero_corpus(id:str,key:str) -> list[dict]:
     corpus = [c for c in corpus if c['data']['abstractNote'] != '']
     def get_collection_path(col_key:str) -> str:
         if p := collections[col_key]['data']['parentCollection']:
-            return get_collection_path(p) + ' / ' + collections[col_key]['data']['name']
+            return get_collection_path(p) + '/' + collections[col_key]['data']['name']
         else:
             return collections[col_key]['data']['name']
     for c in corpus:


### PR DESCRIPTION
### Problem

Collection paths are joined using `' / '` instead of `'/'`, which makes ZOTERO_IGNORE (gitignore-style) rules fail to match correctly, especially when using `!collection/**`.

### Fix

Changed the `get_collection_path()` function to use `'/'` for joining parent and child collection names.

### Impact

- Makes the ignore rules work as expected
- Improves compatibility with `gitignore_parser`
- Does not affect existing logic

Tested locally with paths containing sub-collections and confirms expected behavior.
