### PR TITLE
Add medRxiv as a paper source

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -37,5 +37,9 @@ jobs:
           OPENAI_API_BASE: ${{ secrets.OPENAI_API_BASE }}
           MODEL_NAME: ${{ secrets.MODEL_NAME }}
           LANGUAGE: ${{ vars.LANGUAGE }}
+          MAX_PAPER_NUM_ARXIV: ${{ secrets.MAX_PAPER_NUM_ARXIV || secrets.MAX_PAPER_NUM }}
+          MAX_PAPER_NUM_MEDRXIV: ${{ secrets.MAX_PAPER_NUM_MEDRXIV }}
+          MEDRXIV_DAYS: ${{ secrets.MEDRXIV_DAYS }}
+          MEDRXIV_SUBJECTS: ${{ secrets.MEDRXIV_SUBJECTS }}
         run: |
           uv run main.py

--- a/recommender.py
+++ b/recommender.py
@@ -1,19 +1,22 @@
 import numpy as np
 from sentence_transformers import SentenceTransformer
-from paper import ArxivPaper
+from paper import BasePaper
 from datetime import datetime
 
-def rerank_paper(candidate:list[ArxivPaper],corpus:list[dict],model:str='avsolatorio/GIST-small-Embedding-v0') -> list[ArxivPaper]:
+def rerank_paper(candidate:list[BasePaper],corpus:list[dict],model:str='avsolatorio/GIST-small-Embedding-v0') -> list[BasePaper]:
     encoder = SentenceTransformer(model)
     #sort corpus by date, from newest to oldest
     corpus = sorted(corpus,key=lambda x: datetime.strptime(x['data']['dateAdded'], '%Y-%m-%dT%H:%M:%SZ'),reverse=True)
     time_decay_weight = 1 / (1 + np.log10(np.arange(len(corpus)) + 1))
     time_decay_weight = time_decay_weight / time_decay_weight.sum()
+    
     corpus_feature = encoder.encode([paper['data']['abstractNote'] for paper in corpus])
     candidate_feature = encoder.encode([paper.summary for paper in candidate])
     sim = encoder.similarity(candidate_feature,corpus_feature) # [n_candidate, n_corpus]
     scores = (sim * time_decay_weight).sum(axis=1) * 10 # [n_candidate]
+    
     for s,c in zip(scores,candidate):
         c.score = s.item()
+    
     candidate = sorted(candidate,key=lambda x: x.score,reverse=True)
     return candidate


### PR DESCRIPTION
This PR adds support for fetching and recommending papers from medRxiv, in addition to the existing arXiv source.

To control this new functionality, the following environment variables have been added:

- MEDRXIV_DAYS: Specifies the lookback period for medRxiv papers. If set to 0, medRxiv is disabled. If set to a positive integer, the feature is enabled.
- MEDRXIV_SUBJECTS: Allows filtering medRxiv papers by subject category. The syntax is the same as ARXIV_QUERY.
- MAX_PAPER_NUM_ARXIV: Sets a specific limit for the number of recommended arXiv papers. If not set, it will be automatically obtained from MAX_PAPER_NUM.
- MAX_PAPER_NUM_MEDRXIV: Sets a specific limit for the number of recommended medRxiv papers.

The final email digest is also updated to group papers by their source for better readability.