### PR TITLE
fix: directly assign pdf_url to ArxivPaper._paper.pdf_url when it is None to enable correct pdf downloading

### DIFF
--- a/paper.py
+++ b/paper.py
@@ -40,10 +40,15 @@ class ArxivPaper:
     def pdf_url(self) -> str:
         if self._paper.pdf_url is not None:
             return self._paper.pdf_url
-        elif self._paper.links is not None:
-            return self._paper.links[0].href.replace('abs','pdf')
-        else:
-            return f"https://arxiv.org/pdf/{self.arxiv_id}"
+        
+        pdf_url = f"https://arxiv.org/pdf/{self.arxiv_id}.pdf"
+        if self._paper.links is not None:
+            pdf_url = self._paper.links[0].href.replace('abs','pdf')
+
+        ## Assign pdf_url to self._paper.pdf_url for pdf downloading (Issue #119)
+        self._paper.pdf_url = pdf_url
+
+        return pdf_url
     
     @cached_property
     def code_url(self) -> Optional[str]:


### PR DESCRIPTION
## Problem 
Simply changing pdf_url in ArxivPaper class doesn't solve the download problem, the corresponding attribute in ArxivPaper._paper should be assigned.

## Solution
I assigned the heuristically designated pdf_url to _paper.pdf_url

## Related links
#119 