### PR TITLE
Fix TypeError caused by None values in ArxivPaper tex content

### DIFF
--- a/paper.py
+++ b/paper.py
@@ -167,7 +167,11 @@ class ArxivPaper:
         if self.tex is not None:
             content = self.tex.get("all")
             if content is None:
-                content = "\n".join(self.tex.values())
+                # content = "\n".join(self.tex.values())
+                content = "\n".join([str(v) for v in self.tex.values() if v is not None])
+                if not content.strip():
+                    logger.debug(f"No usable tex content for {self.arxiv_id} when building tldr.")
+
             #remove cite
             content = re.sub(r'~?\\cite.?\{.*?\}', '', content)
             #remove figure
@@ -218,7 +222,11 @@ class ArxivPaper:
         if self.tex is not None:
             content = self.tex.get("all")
             if content is None:
-                content = "\n".join(self.tex.values())
+                # content = "\n".join(self.tex.values())
+                content = "\n".join([str(v) for v in self.tex.values() if v is not None])
+                if not content.strip():
+                    logger.debug(f"Failed to extract affiliations of {self.arxiv_id}: tex content empty after filtering.")
+
             #search for affiliations
             possible_regions = [r'\\author.*?\\maketitle',r'\\begin{document}.*?\\begin{abstract}']
             matches = [re.search(p, content, flags=re.DOTALL) for p in possible_regions]


### PR DESCRIPTION
This PR fixes a crash (`TypeError: sequence item 7: expected str instance, NoneType found`) that occurs when `self.tex.values()` contains `None` values during `tldr` and `affiliations` extraction.

### Changes

1.  **Filter None values:** Modified the `join` logic to explicitly filter out `None` values and convert items to strings before joining (`[str(v) for v in self.tex.values() if v is not None]`).
2.  **Enhanced Logging:** Added debug logs to handle cases where the extracted content is empty or stripped, aiding in future debugging.

### Related Issue / Error Log

Fixes the following traceback:

```text
TypeError: sequence item 7: expected str instance, NoneType found
  File "/home/runner/work/zotero-arxiv-daily/zotero-arxiv-daily/paper.py", line 221, in affiliations
    content = "\n".join(self.tex.values())
```
