### PR TITLE
feat: add keep-alive workflow to prevent scheduled workflow auto-disable

### DIFF
--- a/.github/keep-alive.txt
+++ b/.github/keep-alive.txt
@@ -1,0 +1,2 @@
+Last run: 2026-01-11 00:00:00 UTC
+This file is automatically updated to keep the repository active and prevent GitHub Actions from disabling scheduled workflows.

--- a/.github/workflows/keep-alive.yml
+++ b/.github/workflows/keep-alive.yml
@@ -1,0 +1,36 @@
+name: Keep Alive
+
+on:
+  workflow_dispatch:
+  schedule:
+    # Run every 30 days at 00:00 UTC to keep the repository active
+    - cron: '0 0 */30 * *'
+
+jobs:
+  keep-alive:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Update keep-alive file
+        run: |
+          mkdir -p .github
+          echo "Last run: $(date -u +'%Y-%m-%d %H:%M:%S UTC')" > .github/keep-alive.txt
+          echo "This file is automatically updated to keep the repository active and prevent GitHub Actions from disabling scheduled workflows." >> .github/keep-alive.txt
+
+      - name: Commit and push if changed
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add .github/keep-alive.txt
+          if git diff --staged --quiet; then
+            echo "No changes to commit"
+          else
+            git commit -m "chore: update keep-alive timestamp [skip ci]"
+            git push
+          fi


### PR DESCRIPTION
GitHub automatically disables scheduled workflows after 60 days of repository inactivity. This keep-alive workflow runs every 30 days to update a timestamp file, keeping the repository active and preventing workflow auto-disable.

The workflow:
- Runs every 30 days via cron schedule
- Can be manually triggered via workflow_dispatch
- Updates .github/keep-alive.txt with current timestamp
- Commits changes to maintain repository activity