### PR TITLE
fix: add SMTP_SERVER and SMTP_PORT environment variables to workflows

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -26,6 +26,8 @@ jobs:
           SENDER_PASSWORD: ${{ secrets.SENDER_PASSWORD }}
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
           OPENAI_API_BASE: ${{ secrets.OPENAI_API_BASE }}
+          SMTP_SERVER: ${{ secrets.SMTP_SERVER }}
+          SMTP_PORT: ${{ secrets.SMTP_PORT }}
           CUSTOM_CONFIG: ${{ vars.CUSTOM_CONFIG }}
         run: |
           printf "%b\n" "$CUSTOM_CONFIG" > config/custom.yaml

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -25,6 +25,8 @@ jobs:
           SENDER_PASSWORD: ${{ secrets.SENDER_PASSWORD }}
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
           OPENAI_API_BASE: ${{ secrets.OPENAI_API_BASE }}
+          SMTP_SERVER: ${{ secrets.SMTP_SERVER }}
+          SMTP_PORT: ${{ secrets.SMTP_PORT }}
           CUSTOM_CONFIG: ${{ vars.CUSTOM_CONFIG }}
         run: |
           export DEBUG=true

--- a/README.md
+++ b/README.md
@@ -65,6 +65,8 @@ Below are all the secrets you need to set. They are invisible to anyone includin
 | SENDER | The email account of the SMTP server that sends you email. | abc@qq.com |
 | SENDER_PASSWORD | The password of the sender account. Note that it's not necessarily the password for logging in the e-mail client, but the authentication code for SMTP service. Ask your email provider for this.   | abcdefghijklmn |
 | RECEIVER | The e-mail address that receives the paper list. | abc@outlook.com |
+| SMTP_SERVER | (Optional) The SMTP server address. If not set in secrets, you must hardcode it in CUSTOM_CONFIG. | smtp.qq.com |
+| SMTP_PORT | (Optional) The SMTP server port. If not set in secrets, you must hardcode it in CUSTOM_CONFIG. | 465 |
 | OPENAI_API_KEY | API Key when using the API to access LLMs. You can get FREE API for using advanced open source LLMs in [SiliconFlow](https://cloud.siliconflow.cn/i/b3XhBRAm). | sk-xxx |
 | OPENAI_API_BASE | API URL when using the API to access LLMs. | https://api.siliconflow.cn/v1 |
 
@@ -81,8 +83,8 @@ zotero:
 email:
   sender: ${oc.env:SENDER}
   receiver: ${oc.env:RECEIVER}
-  smtp_server: smtp.qq.com
-  smtp_port: 465
+  smtp_server: smtp.qq.com  # Change this to your SMTP server, or use ${oc.env:SMTP_SERVER} if you set it as a secret
+  smtp_port: 465  # Change this to your SMTP port, or use ${oc.env:SMTP_PORT} if you set it as a secret
   sender_password: ${oc.env:SENDER_PASSWORD}
 
 llm:


### PR DESCRIPTION
## Problem
The GitHub Actions workflows were failing with `InterpolationResolutionError` because the `CUSTOM_CONFIG` variable referenced `${oc.env:SMTP_SERVER}` and `${oc.env:SMTP_PORT}`, but these environment variables were not defined in the workflow files.

## Solution
- Added `SMTP_SERVER` and `SMTP_PORT` environment variables to both `main.yml` and `test.yml` workflows
- Updated README.md to document these optional secrets
- Added helpful comments in the CUSTOM_CONFIG example explaining the two configuration options

## Testing
- ✅ CI workflow now passes successfully
- ✅ Users can either:
  1. Set SMTP_SERVER and SMTP_PORT as secrets and reference them with `${oc.env:SMTP_SERVER}`
  2. Hardcode the values directly in CUSTOM_CONFIG (e.g., `smtp.qq.com` and `465`)

Fixes the issue where workflows fail with:
```
omegaconf.errors.InterpolationResolutionError: KeyError raised while resolving interpolation: "Environment variable 'SMTP_SERVER' not found"
```