### PR TITLE
fix: set max_paper_num to 10 in custom config

### DIFF
--- a/config/custom.yaml
+++ b/config/custom.yaml
@@ -24,3 +24,4 @@ source:
 executor:
   debug: ${oc.env:DEBUG,null}
   source: ['arxiv']
+  max_paper_num: 10


### PR DESCRIPTION
The old MAX_PAPER_NUM secret is no longer used after the codebase refactor. Add max_paper_num: 10 to custom.yaml to restore the desired paper limit.

https://claude.ai/code/session_01Hz6YdR6RnkLVYFkVBNGkB7