### PR TITLE
fix local reranker loading for Jina remote code

### DIFF
--- a/src/zotero_arxiv_daily/reranker/local.py
+++ b/src/zotero_arxiv_daily/reranker/local.py
@@ -1,7 +1,32 @@
 from .base import BaseReranker, register_reranker
+from contextlib import contextmanager
 import logging
 import warnings
 import numpy as np
+
+
+@contextmanager
+def _dedupe_trust_remote_code_for_tokenizer():
+    from sentence_transformers.models import Transformer
+
+    original = Transformer._load_init_kwargs.__func__
+
+    def patched(cls, *args, **kwargs):
+        init_kwargs = original(cls, *args, **kwargs)
+        tokenizer_args = init_kwargs.get("tokenizer_args")
+        if tokenizer_args:
+            tokenizer_args = dict(tokenizer_args)
+            tokenizer_args.pop("trust_remote_code", None)
+            init_kwargs["tokenizer_args"] = tokenizer_args
+        return init_kwargs
+
+    setattr(Transformer, "_load_init_kwargs", classmethod(patched))
+    try:
+        yield
+    finally:
+        setattr(Transformer, "_load_init_kwargs", classmethod(original))
+
+
 @register_reranker("local")
 class LocalReranker(BaseReranker):
     def get_similarity_score(self, s1: list[str], s2: list[str]) -> np.ndarray:
@@ -19,7 +44,10 @@ class LocalReranker(BaseReranker):
             logging.getLogger("huggingface_hub.utils._http").setLevel(logging.ERROR)
             warnings.filterwarnings("ignore", category=FutureWarning)
 
-        encoder = SentenceTransformer(self.config.reranker.local.model, trust_remote_code=True)
+        with _dedupe_trust_remote_code_for_tokenizer():
+            encoder = SentenceTransformer(
+                self.config.reranker.local.model, trust_remote_code=True
+            )
         if self.config.reranker.local.encode_kwargs:
             encode_kwargs = self.config.reranker.local.encode_kwargs
         else:


### PR DESCRIPTION
## Summary
- avoid passing `trust_remote_code` twice when the local reranker loads `jinaai/jina-embeddings-v5-text-nano`
- monkey patch `sentence_transformers.models.Transformer._load_init_kwargs` only around model construction so tokenizer kwargs are deduplicated
- close the regression reported in #226

## Test Plan
- [x] `uv run pytest tests/reranker/test_base_reranker.py tests/reranker/test_local_reranker.py -m \"not slow or slow\" -q`
- [x] `uv run python -c \"from sentence_transformers import SentenceTransformer; from zotero_arxiv_daily.reranker.local import _dedupe_trust_remote_code_for_tokenizer; print('about to load');\nwith _dedupe_trust_remote_code_for_tokenizer():\n    SentenceTransformer('jinaai/jina-embeddings-v5-text-nano', trust_remote_code=True)\nprint('loaded')\"`