### PR TITLE
fix: add retry and rate limiting for arXiv API 429 errors

### DIFF
--- a/src/zotero_arxiv_daily/retriever/arxiv_retriever.py
+++ b/src/zotero_arxiv_daily/retriever/arxiv_retriever.py
@@ -9,6 +9,7 @@ from tqdm import tqdm
 import multiprocessing
 import os
 from queue import Empty
+from time import sleep
 from typing import Any, Callable, TypeVar
 from loguru import logger
 import requests
@@ -132,11 +133,25 @@ class ArxivRetriever(BaseRetriever):
 
         # Get full information of each paper from arxiv api
         bar = tqdm(total=len(all_paper_ids))
+        max_batch_retries = 5
+        batch_retry_delay = 30
         for i in range(0, len(all_paper_ids), 20):
             search = arxiv.Search(id_list=all_paper_ids[i:i + 20])
-            batch = list(client.results(search))
-            bar.update(len(batch))
-            raw_papers.extend(batch)
+            for attempt in range(max_batch_retries):
+                try:
+                    batch = list(client.results(search))
+                    bar.update(len(batch))
+                    raw_papers.extend(batch)
+                    break
+                except arxiv.HTTPError as exc:
+                    if exc.status == 429 and attempt < max_batch_retries - 1:
+                        wait = batch_retry_delay * (attempt + 1)
+                        logger.warning(f"arXiv API 429 on batch {i // 20}, retry {attempt + 1}/{max_batch_retries} in {wait}s")
+                        sleep(wait)
+                    else:
+                        raise
+            if i + 20 < len(all_paper_ids):
+                sleep(3)
         bar.close()
 
         return raw_papers


### PR DESCRIPTION
## Closes #248

## Problem

When running the GitHub Actions test workflow, the arXiv retriever fetches paper details in batches of 20 via the arXiv API. Consecutive batch requests with no delay trigger HTTP 429 (Too Many Requests) errors, crashing the entire pipeline.

## Changes

Modified \src/zotero_arxiv_daily/retriever/arxiv_retriever.py\:

1. **Batch-level 429 retry**: Each batch (20 papers) retries up to 5 times with linear backoff (30s, 60s, 90s, 120s, 150s) when receiving HTTP 429.
2. **Inter-batch delay**: Added 3-second sleep between consecutive batches to reduce rate limit triggering.
3. **Precise exception handling**: Only retry on \rxiv.HTTPError\ with \status == 429\; all other errors propagate immediately.

## Testing

- Core test \	est_arxiv_retriever\ passes
- Successfully deployed and tested via GitHub Actions test workflow

<!-- Screenshots of test workflow failure and success can be attached here -->
<img width="2980" height="1736" alt="image" src="https://github.com/user-attachments/assets/73c5a7b9-0a31-482f-b18e-586e76fe6f5a" />
