### PR TITLE
Harden arXiv retrieval against batch API failures in `calculate-and-send`

### DIFF
--- a/.github/keep-alive.txt
+++ b/.github/keep-alive.txt
@@ -1,2 +1,2 @@
-Last run: 2026-06-01 01:12:30 UTC
+Last run: 2026-07-01 02:42:19 UTC
 This file is automatically updated to keep the repository active and prevent GitHub Actions from disabling scheduled workflows.

--- a/src/zotero_arxiv_daily/executor.py
+++ b/src/zotero_arxiv_daily/executor.py
@@ -120,5 +120,7 @@ class Executor:
             return
         logger.info("Sending email...")
         email_content = render_email(reranked_papers)
-        send_email(self.config, email_content)
-        logger.info("Email sent successfully")
+        if send_email(self.config, email_content):
+            logger.info("Email sent successfully")
+        else:
+            logger.warning("Email could not be sent")

--- a/src/zotero_arxiv_daily/retriever/arxiv_retriever.py
+++ b/src/zotero_arxiv_daily/retriever/arxiv_retriever.py
@@ -136,7 +136,8 @@ class ArxivRetriever(BaseRetriever):
         max_batch_retries = 5
         batch_retry_delay = 30
         for i in range(0, len(all_paper_ids), 20):
-            search = arxiv.Search(id_list=all_paper_ids[i:i + 20])
+            batch_ids = all_paper_ids[i:i + 20]
+            search = arxiv.Search(id_list=batch_ids)
             for attempt in range(max_batch_retries):
                 try:
                     batch = list(client.results(search))
@@ -144,12 +145,37 @@ class ArxivRetriever(BaseRetriever):
                     raw_papers.extend(batch)
                     break
                 except arxiv.HTTPError as exc:
-                    if exc.status == 429 and attempt < max_batch_retries - 1:
-                        wait = batch_retry_delay * (attempt + 1)
-                        logger.warning(f"arXiv API 429 on batch {i // 20}, retry {attempt + 1}/{max_batch_retries} in {wait}s")
-                        sleep(wait)
+                    if exc.status == 429:
+                        if attempt < max_batch_retries - 1:
+                            wait = batch_retry_delay * (attempt + 1)
+                            logger.warning(
+                                f"arXiv API 429 on batch {i // 20}, "
+                                f"retry {attempt + 1}/{max_batch_retries} in {wait}s"
+                            )
+                            sleep(wait)
+                            continue
+                        logger.warning(
+                            f"arXiv API 429 on batch {i // 20} after {max_batch_retries} retries. "
+                            "Falling back to per-paper requests."
+                        )
                     else:
-                        raise
+                        logger.warning(
+                            f"arXiv API error on batch {i // 20} (status {exc.status}). "
+                            "Falling back to per-paper requests."
+                        )
+                    batch = []
+                    for index, paper_id in enumerate(batch_ids):
+                        try:
+                            batch.extend(list(client.results(arxiv.Search(id_list=[paper_id]))))
+                        except arxiv.HTTPError as paper_exc:
+                            logger.warning(
+                                f"Skipping arXiv paper {paper_id} due to API error status {paper_exc.status}"
+                            )
+                        if index + 1 < len(batch_ids):
+                            sleep(1)
+                    bar.update(len(batch))
+                    raw_papers.extend(batch)
+                    break
             if i + 20 < len(all_paper_ids):
                 sleep(3)
         bar.close()

--- a/src/zotero_arxiv_daily/utils.py
+++ b/src/zotero_arxiv_daily/utils.py
@@ -139,7 +139,7 @@ def glob_match(path:str, pattern:str) -> bool:
     re_pattern = glob.translate(pattern,recursive=True)
     return re.match(re_pattern, path) is not None
 
-def send_email(config:DictConfig, html:str):
+def send_email(config:DictConfig, html:str) -> bool:
     sender = config.email.sender
     receiver = config.email.receiver
     password = config.email.sender_password
@@ -164,8 +164,21 @@ def send_email(config:DictConfig, html:str):
             server = smtplib.SMTP_SSL(smtp_server, smtp_port)
         except Exception as e:
             logger.debug(f"Failed to use SSL. {e}\nTry to use plain text.")
-            server = smtplib.SMTP(smtp_server, smtp_port)
+            try:
+                server = smtplib.SMTP(smtp_server, smtp_port)
+            except Exception as e:
+                logger.warning(f"Failed to connect to SMTP server. Email not sent. {e}")
+                return False
 
-    server.login(sender, password)
-    server.sendmail(sender, [receiver], msg.as_string())
-    server.quit()
+    try:
+        server.login(sender, password)
+        server.sendmail(sender, [receiver], msg.as_string())
+        return True
+    except Exception as e:
+        logger.warning(f"Failed to send email. {e}")
+        return False
+    finally:
+        try:
+            server.quit()
+        except Exception:
+            pass

--- a/src/zotero_arxiv_daily/utils.py
+++ b/src/zotero_arxiv_daily/utils.py
@@ -136,7 +136,7 @@ def extract_markdown_from_pdf(file_path:str) -> str:
     return pymupdf4llm.to_markdown(file_path,use_ocr=False,header=False,footer=False,ignore_code=True)
 
 def glob_match(path:str, pattern:str) -> bool:
-    re_pattern = glob.translate(pattern,recursive=True)
+    re_pattern = glob.translate(pattern, recursive=True)
     return re.match(re_pattern, path) is not None
 
 def send_email(config: DictConfig, html: str) -> bool:

--- a/src/zotero_arxiv_daily/utils.py
+++ b/src/zotero_arxiv_daily/utils.py
@@ -136,10 +136,10 @@ def extract_markdown_from_pdf(file_path:str) -> str:
     return pymupdf4llm.to_markdown(file_path,use_ocr=False,header=False,footer=False,ignore_code=True)
 
 def glob_match(path:str, pattern:str) -> bool:
-    re_pattern = glob.translate(pattern,recursive=True)
+    re_pattern = glob.translate(pattern, recursive=True)
     return re.match(re_pattern, path) is not None
 
-def send_email(config:DictConfig, html:str):
+def send_email(config: DictConfig, html: str) -> bool:
     sender = config.email.sender
     receiver = config.email.receiver
     password = config.email.sender_password
@@ -164,8 +164,21 @@ def send_email(config:DictConfig, html:str):
             server = smtplib.SMTP_SSL(smtp_server, smtp_port)
         except Exception as e:
             logger.debug(f"Failed to use SSL. {e}\nTry to use plain text.")
-            server = smtplib.SMTP(smtp_server, smtp_port)
+            try:
+                server = smtplib.SMTP(smtp_server, smtp_port)
+            except Exception as e:
+                logger.warning(f"Failed to connect to SMTP server: {e}")
+                return False
 
-    server.login(sender, password)
-    server.sendmail(sender, [receiver], msg.as_string())
-    server.quit()
+    try:
+        server.login(sender, password)
+        server.sendmail(sender, [receiver], msg.as_string())
+        return True
+    except Exception as e:
+        logger.warning(f"Failed to send email. {e}")
+        return False
+    finally:
+        try:
+            server.quit()
+        except Exception as e:
+            logger.debug(f"Failed to close SMTP connection: {e}")

--- a/src/zotero_arxiv_daily/utils.py
+++ b/src/zotero_arxiv_daily/utils.py
@@ -139,7 +139,7 @@ def glob_match(path:str, pattern:str) -> bool:
     re_pattern = glob.translate(pattern,recursive=True)
     return re.match(re_pattern, path) is not None
 
-def send_email(config:DictConfig, html:str) -> bool:
+def send_email(config: DictConfig, html: str) -> bool:
     sender = config.email.sender
     receiver = config.email.receiver
     password = config.email.sender_password

--- a/src/zotero_arxiv_daily/utils.py
+++ b/src/zotero_arxiv_daily/utils.py
@@ -167,7 +167,7 @@ def send_email(config: DictConfig, html: str) -> bool:
             try:
                 server = smtplib.SMTP(smtp_server, smtp_port)
             except Exception as e:
-                logger.warning(f"Failed to connect to SMTP server. Email not sent. {e}")
+                logger.warning(f"Failed to connect to SMTP server: {e}")
                 return False
 
     try:
@@ -180,5 +180,5 @@ def send_email(config: DictConfig, html: str) -> bool:
     finally:
         try:
             server.quit()
-        except Exception:
-            pass
+        except Exception as e:
+            logger.debug(f"Failed to close SMTP connection: {e}")

--- a/tests/retriever/test_arxiv_retriever.py
+++ b/tests/retriever/test_arxiv_retriever.py
@@ -88,3 +88,54 @@ def test_run_with_hard_timeout_returns_none_on_failure(monkeypatch):
     )
     assert result is None
     assert "boom" in warnings[0]
+
+
+def test_arxiv_retriever_falls_back_to_per_paper_on_batch_http_error(config, mock_feedparser, monkeypatch):
+    monkeypatch.setattr("zotero_arxiv_daily.retriever.base.sleep", lambda _: None)
+
+    new_entries = [
+        e for e in mock_feedparser.entries
+        if e.get("arxiv_announce_type", "new") == "new"
+    ]
+
+    fake_results_by_id = {}
+    for entry in new_entries:
+        pid = entry.id.removeprefix("oai:arXiv.org:")
+        fake_results_by_id[pid] = SimpleNamespace(
+            title=entry.title,
+            authors=[SimpleNamespace(name="Test Author")],
+            summary="Test abstract",
+            pdf_url=f"https://arxiv.org/pdf/{pid}",
+            entry_id=f"https://arxiv.org/abs/{pid}",
+            source_url=lambda pid=pid: f"https://arxiv.org/e-print/{pid}",
+        )
+
+    skipped_pid = next(iter(fake_results_by_id))
+    warnings: list[str] = []
+
+    class FakeClient:
+        def __init__(self, **kw):
+            pass
+
+        def results(self, search):
+            ids = list(search.id_list)
+            if len(ids) > 1:
+                raise arxiv_retriever.arxiv.HTTPError("https://export.arxiv.org/api/query", 0, 406)
+            pid = ids[0]
+            if pid == skipped_pid:
+                raise arxiv_retriever.arxiv.HTTPError("https://export.arxiv.org/api/query", 0, 406)
+            return iter([fake_results_by_id[pid]])
+
+    monkeypatch.setattr(arxiv_retriever.arxiv, "Client", FakeClient)
+    monkeypatch.setattr(arxiv_retriever, "logger", SimpleNamespace(warning=warnings.append))
+    monkeypatch.setattr(arxiv_retriever, "extract_text_from_html", lambda paper: None)
+    monkeypatch.setattr(arxiv_retriever, "extract_text_from_pdf", lambda paper: None)
+    monkeypatch.setattr(arxiv_retriever, "extract_text_from_tar", lambda paper: None)
+
+    retriever = ArxivRetriever(config)
+    papers = retriever.retrieve_papers()
+
+    assert len(papers) == len(new_entries) - 1
+    assert skipped_pid not in {p.url.removeprefix("https://arxiv.org/abs/") for p in papers}
+    assert any("Falling back to per-paper requests" in w for w in warnings)
+    assert any(f"Skipping arXiv paper {skipped_pid}" in w for w in warnings)

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -187,12 +187,12 @@ def test_send_email_falls_back_to_plain(config, monkeypatch):
 
 
 def test_send_email_connection_failure_returns_false(config, monkeypatch):
-    class StubSMTP_Fails:
+    class StubSMTPFails:
         def __init__(self, *a, **kw):
             raise OSError("Network is unreachable")
 
-    monkeypatch.setattr(smtplib, "SMTP", StubSMTP_Fails)
-    monkeypatch.setattr(smtplib, "SMTP_SSL", StubSMTP_Fails)
+    monkeypatch.setattr(smtplib, "SMTP", StubSMTPFails)
+    monkeypatch.setattr(smtplib, "SMTP_SSL", StubSMTPFails)
     assert send_email(config, "<html>down</html>") is False
 
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -186,6 +186,16 @@ def test_send_email_falls_back_to_plain(config, monkeypatch):
     assert len(sent) == 1
 
 
+def test_send_email_connection_failure_returns_false(config, monkeypatch):
+    class StubSMTP_Fails:
+        def __init__(self, *a, **kw):
+            raise OSError("Network is unreachable")
+
+    monkeypatch.setattr(smtplib, "SMTP", StubSMTP_Fails)
+    monkeypatch.setattr(smtplib, "SMTP_SSL", StubSMTP_Fails)
+    assert send_email(config, "<html>down</html>") is False
+
+
 # ---------------------------------------------------------------------------
 # extract_tex_code_from_tar
 # ---------------------------------------------------------------------------

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -186,6 +186,16 @@ def test_send_email_falls_back_to_plain(config, monkeypatch):
     assert len(sent) == 1
 
 
+def test_send_email_connection_failure_returns_false(config, monkeypatch):
+    class StubSMTPFails:
+        def __init__(self, *a, **kw):
+            raise OSError("Network is unreachable")
+
+    monkeypatch.setattr(smtplib, "SMTP", StubSMTPFails)
+    monkeypatch.setattr(smtplib, "SMTP_SSL", StubSMTPFails)
+    assert send_email(config, "<html>down</html>") is False
+
+
 # ---------------------------------------------------------------------------
 # extract_tex_code_from_tar
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
arxiv Python 库请求 https://export.arxiv.org/api/query?...id_list=... 时返回了 HTTP 406，导致任务直接退出。

在 `ArxivRetriever` 内实现了“限流 + 分批 + 重试”，并且把 406 场景改成降级不退出：

- 分批：按 `20` 个 paper ID 一批请求 arXiv API。
- 限流：批次之间 `sleep(3)`；降级到单篇请求时每篇之间 `sleep(1)`。
- 重试：
  - `arxiv.Client(num_retries=10, delay_seconds=10)` 保留库内重试；
  - 对 `429` 增加批级重试（最多 5 次，30s 线性退避）。
- 406/其他 HTTP 错误：批请求失败后转为单篇请求；单篇仍失败的 ID 只记录 warning 并跳过，不再让 workflow 直接失败。

测试了一下，不影响正常运行。