### PR TITLE
fix: parse BioRxiv dates chronologically

### DIFF
--- a/src/zotero_arxiv_daily/retriever/biorxiv_retriever.py
+++ b/src/zotero_arxiv_daily/retriever/biorxiv_retriever.py
@@ -1,3 +1,5 @@
+from datetime import datetime
+
 import requests
 from .base import BaseRetriever, register_retriever
 from ..protocol import Paper
@@ -34,9 +36,12 @@ class BiorxivRetriever(BaseRetriever):
         if len(collection) == 0:
             logger.warning(f"No paper found. API Message: {result['messages']}")
             return []
-        all_dates = set(c['date'] for c in collection)
-        latest_date = sorted(all_dates)[-1]
-        collection = [c for c in collection if c['date'] == latest_date]
+        dated_collection = [
+            (datetime.strptime(c['date'], "%Y-%m-%d").date(), c)
+            for c in collection
+        ]
+        latest_date = max(date for date, _ in dated_collection)
+        collection = [c for date, c in dated_collection if date == latest_date]
         categories = [c.lower() for c in self.retriever_config.category]
         collection = [c for c in collection if c['category'] in categories]
         if self.config.executor.debug:

--- a/tests/retriever/test_biorxiv_retriever.py
+++ b/tests/retriever/test_biorxiv_retriever.py
@@ -39,6 +39,34 @@ def test_biorxiv_empty_response(config, monkeypatch):
     assert papers == []
 
 
+def test_biorxiv_orders_unpadded_dates_chronologically(config, monkeypatch):
+    import requests
+    from types import SimpleNamespace
+
+    response = {
+        "messages": [{"status": "ok"}],
+        "collection": [
+            {"date": "2026-6-30", "category": "neuroscience"},
+            {"date": "2026-07-15", "category": "bioinformatics"},
+        ],
+    }
+
+    def _patched(url, **kw):
+        result = SimpleNamespace(status_code=200, raise_for_status=lambda: None)
+        result.json = lambda: response
+        return result
+
+    monkeypatch.setattr(requests, "get", _patched)
+
+    with open_dict(config.source):
+        config.source.biorxiv = {"category": ["bioinformatics"]}
+    retriever = BiorxivRetriever(config)
+
+    raw_papers = retriever._retrieve_raw_papers()
+
+    assert raw_papers == [response["collection"][1]]
+
+
 def test_biorxiv_convert_to_paper(config):
     with open_dict(config.source):
         config.source.biorxiv = {"category": ["bioinformatics"]}


### PR DESCRIPTION
## Summary

BioRxiv can return non-zero-padded dates such as `2026-6-30`. Lexicographic sorting therefore incorrectly ranks that value after `2026-07-15`, which can discard valid current papers before category filtering.

This change parses dates before selecting the latest one and adds a regression test for the June-versus-July ordering case.

## Testing

- `uv run pytest -q` — 83 passed, 1 deselected
- [GitHub Actions CI](https://github.com/level6626/zotero-arxiv-daily/actions/runs/29453327641) — passed