### PR TITLE
feat: add chemRxiv as a paper source (via Crossref)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -33,7 +33,7 @@ The app follows a linear pipeline orchestrated by `Executor` (`src/zotero_arxiv_
 
 1. **Fetch Zotero corpus** — retrieves user's library papers via pyzotero API
 2. **Filter corpus** — applies `include_path` glob patterns to select relevant collections
-3. **Retrieve new papers** — fetches from configured sources (arXiv RSS, bioRxiv/medRxiv REST API, chemRxiv Open Engage API)
+3. **Retrieve new papers** — fetches from configured sources (arXiv RSS, bioRxiv/medRxiv REST API, chemRxiv via Crossref REST API)
 4. **Rerank** — scores candidates by weighted similarity to corpus (newer Zotero papers weighted higher)
 5. **Generate TLDRs + affiliations** — via OpenAI-compatible LLM API
 6. **Render + send email** — HTML email via SMTP

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,7 +4,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## Project Overview
 
-Zotero-arXiv-Daily recommends new arXiv/bioRxiv/medRxiv papers based on a user's Zotero library. It computes embedding similarity between new papers and the user's existing library, generates TLDRs via LLM, and delivers results by email. Designed to run as a GitHub Actions workflow at zero cost.
+Zotero-arXiv-Daily recommends new arXiv/bioRxiv/medRxiv/chemRxiv papers based on a user's Zotero library. It computes embedding similarity between new papers and the user's existing library, generates TLDRs via LLM, and delivers results by email. Designed to run as a GitHub Actions workflow at zero cost.
 
 ## Commands
 
@@ -33,7 +33,7 @@ The app follows a linear pipeline orchestrated by `Executor` (`src/zotero_arxiv_
 
 1. **Fetch Zotero corpus** — retrieves user's library papers via pyzotero API
 2. **Filter corpus** — applies `include_path` glob patterns to select relevant collections
-3. **Retrieve new papers** — fetches from configured sources (arXiv RSS, bioRxiv/medRxiv REST API)
+3. **Retrieve new papers** — fetches from configured sources (arXiv RSS, bioRxiv/medRxiv REST API, chemRxiv Open Engage API)
 4. **Rerank** — scores candidates by weighted similarity to corpus (newer Zotero papers weighted higher)
 5. **Generate TLDRs + affiliations** — via OpenAI-compatible LLM API
 6. **Render + send email** — HTML email via SMTP

--- a/README.md
+++ b/README.md
@@ -122,7 +122,7 @@ source:
   medrxiv:
     category: null # The categories of target medrxiv papers. Find categories from [here](https://www.medrxiv.org/) Example: ["psychiatry and clinical psychology", "neurology"]
   chemrxiv:
-    category: null # The categories of target chemrxiv papers, or null for all categories. Find categories from [here](https://chemrxiv.org/engage/chemrxiv/public-dashboard). Example: ["Theoretical and Computational Chemistry", "Materials Science"]
+    include_new_versions: false # Whether to include revised versions (v2, v3, ...) of previously posted chemrxiv preprints in addition to new first postings. chemrxiv has no category filter: all new preprints (a few dozen per day) are retrieved via Crossref and left to the reranker. Example: true
 
 email:
   sender: ??? # The email account of the SMTP server that sends you email. Example: abc@qq.com

--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@
   - arxiv
   - biorxiv
   - medrxiv
+  - chemrxiv
 
 ## 📷 Screenshot
 ![screenshot](./assets/screenshot.png)
@@ -120,6 +121,8 @@ source:
     category: null # The categories of target biorxiv papers. Find categories from [here](https://www.biorxiv.org/). Example: ["biochemistry","animal behavior and cognition"]
   medrxiv:
     category: null # The categories of target medrxiv papers. Find categories from [here](https://www.medrxiv.org/) Example: ["psychiatry and clinical psychology", "neurology"]
+  chemrxiv:
+    category: null # The categories of target chemrxiv papers, or null for all categories. Find categories from [here](https://chemrxiv.org/engage/chemrxiv/public-dashboard). Example: ["Theoretical and Computational Chemistry", "Materials Science"]
 
 email:
   sender: ??? # The email account of the SMTP server that sends you email. Example: abc@qq.com
@@ -155,7 +158,7 @@ executor:
   debug: false # Whether to use debug mode. Example: true
   send_empty: false # Whether to send an empty email even if no new papers today. Example: true
   max_paper_num: 100 # The maximum number of the papers presented in the email. Example: 100
-  source: ??? # The sources of papers to retrieve. Example: ['arxiv','biorxiv','medrxiv']
+  source: ??? # The sources of papers to retrieve. Example: ['arxiv','biorxiv','medrxiv','chemrxiv']
   reranker: local # The reranker to use. Example: 'local' or 'api'
 ```
 

--- a/config/base.yaml
+++ b/config/base.yaml
@@ -12,6 +12,8 @@ source:
     category: null # The categories of target biorxiv papers. Find categories from [here](https://www.biorxiv.org/). Example: ["biochemistry","animal behavior and cognition"]
   medrxiv:
     category: null # The categories of target medrxiv papers. Find categories from [here](https://www.medrxiv.org/) Example: ["psychiatry and clinical psychology", "neurology"]
+  chemrxiv:
+    category: null # The categories of target chemrxiv papers, or null for all categories. Find categories from [here](https://chemrxiv.org/engage/chemrxiv/public-dashboard). Example: ["Theoretical and Computational Chemistry", "Materials Science"]
 
 email:
   sender: ??? # The email account of the SMTP server that sends you email. Example: abc@qq.com
@@ -47,5 +49,5 @@ executor:
   debug: false # Whether to use debug mode. Example: true
   send_empty: false # Whether to send an empty email even if no new papers today. Example: true
   max_paper_num: 100 # The maximum number of the papers presented in the email. Example: 100
-  source: ??? # The sources of papers to retrieve. Example: ['arxiv','biorxiv','medrxiv']
+  source: ??? # The sources of papers to retrieve. Example: ['arxiv','biorxiv','medrxiv','chemrxiv']
   reranker: local # The reranker to use. Example: 'local' or 'api'

--- a/config/base.yaml
+++ b/config/base.yaml
@@ -13,7 +13,7 @@ source:
   medrxiv:
     category: null # The categories of target medrxiv papers. Find categories from [here](https://www.medrxiv.org/) Example: ["psychiatry and clinical psychology", "neurology"]
   chemrxiv:
-    category: null # The categories of target chemrxiv papers, or null for all categories. Find categories from [here](https://chemrxiv.org/engage/chemrxiv/public-dashboard). Example: ["Theoretical and Computational Chemistry", "Materials Science"]
+    include_new_versions: false # Whether to include revised versions (v2, v3, ...) of previously posted chemrxiv preprints in addition to new first postings. chemrxiv has no category filter: all new preprints (a few dozen per day) are retrieved via Crossref and left to the reranker. Example: true
 
 email:
   sender: ??? # The email account of the SMTP server that sends you email. Example: abc@qq.com

--- a/src/zotero_arxiv_daily/retriever/__init__.py
+++ b/src/zotero_arxiv_daily/retriever/__init__.py
@@ -1,2 +1,2 @@
 from .base import get_retriever_cls
-from . import arxiv_retriever, biorxiv_retriever, medrxiv_retriever
+from . import arxiv_retriever, biorxiv_retriever, medrxiv_retriever, chemrxiv_retriever

--- a/src/zotero_arxiv_daily/retriever/chemrxiv_retriever.py
+++ b/src/zotero_arxiv_daily/retriever/chemrxiv_retriever.py
@@ -53,10 +53,10 @@ class ChemrxivRetriever(BaseRetriever):
                 )
                 response.raise_for_status()
                 return response.json()
-            except Exception as e:
+            except Exception as exc:
                 if i == retry_num - 1:
-                    raise e
-                logger.warning(f"Failed to retrieve papers: {str(e)}. Retry in {delay_time} seconds.")
+                    raise
+                logger.warning(f"Failed to retrieve papers: {exc}. Retry in {delay_time} seconds.")
                 sleep(delay_time)
 
     @staticmethod

--- a/src/zotero_arxiv_daily/retriever/chemrxiv_retriever.py
+++ b/src/zotero_arxiv_daily/retriever/chemrxiv_retriever.py
@@ -1,3 +1,5 @@
+import html
+import re
 from datetime import datetime, timedelta, timezone
 from time import sleep
 from typing import Any
@@ -11,24 +13,32 @@ from ..protocol import Paper
 
 @register_retriever("chemrxiv")
 class ChemrxivRetriever(BaseRetriever):
-    """Retrieve recent preprints from chemRxiv via the Cambridge Open Engage public API.
+    """Retrieve recent chemRxiv preprints via the Crossref REST API.
 
-    chemRxiv publishes preprints continuously rather than in daily batches, so this
-    retriever collects every item published within the last ``lookback_hours`` hours
-    (24 by default) instead of keeping only the latest posting date as the bioRxiv
-    retriever does. Items are fetched newest-first and pagination stops as soon as
-    an item older than the cutoff is seen.
+    chemRxiv moved from Cambridge Open Engage to Wiley's Research Exchange platform
+    in January 2026; the old ``public-api`` is gone and the new site sits behind
+    Cloudflare bot protection. Every chemRxiv preprint is registered with Crossref
+    under the ACS prefix ``10.26434`` within minutes of posting, with title,
+    abstract, authors, affiliations and links, so Crossref is used as the source.
+
+    chemRxiv publishes continuously rather than in daily batches, so this retriever
+    keeps every record whose Crossref ``created`` timestamp (the deposit time, which
+    coincides with posting) falls within the last ``lookback_hours`` hours. Crossref
+    does not expose chemRxiv subject categories, so there is no category filter;
+    chemRxiv volume is small (a few dozen preprints per day) and the reranker does
+    the selection.
     """
 
-    api_url = "https://chemrxiv.org/engage/chemrxiv/public-api/v1/items"
-    article_url = "https://chemrxiv.org/engage/chemrxiv/article-details/{id}"
-    page_size = 50  # API maximum
-    max_pages = 20  # safety cap: 1000 items is far more than one day of chemRxiv output
+    api_url = "https://api.crossref.org/prefixes/10.26434/works"
+    page_size = 100
+    max_pages = 20
     lookback_hours = 24
     request_headers = {
         "User-Agent": "zotero-arxiv-daily (https://github.com/TideDra/zotero-arxiv-daily)",
         "Accept": "application/json",
     }
+    _version_suffix = re.compile(r"[/-]v(\d+)$", re.IGNORECASE)
+    _tag = re.compile(r"<[^>]+>")
 
     def _get_json(self, params: dict[str, Any]) -> dict[str, Any]:
         retry_num = 10
@@ -61,40 +71,41 @@ class ChemrxivRetriever(BaseRetriever):
             parsed = parsed.replace(tzinfo=timezone.utc)
         return parsed
 
+    def _is_new_version(self, doi: str) -> bool:
+        match = self._version_suffix.search(doi)
+        return match is not None and int(match.group(1)) > 1
+
     def _retrieve_raw_papers(self) -> list[dict[str, Any]]:
         cutoff = datetime.now(timezone.utc) - timedelta(hours=self.lookback_hours)
-        categories = self.retriever_config.category
-        if categories is not None:
-            categories = {c.lower() for c in categories}
+        include_new_versions = bool(getattr(self.retriever_config, "include_new_versions", False))
 
         collection = []
         for page in range(self.max_pages):
             result = self._get_json(
                 {
-                    "limit": self.page_size,
-                    "skip": page * self.page_size,
-                    "sort": "PUBLISHED_DATE_DESC",
+                    "filter": f"type:posted-content,from-created-date:{cutoff.date().isoformat()}",
+                    "sort": "created",
+                    "order": "desc",
+                    "rows": self.page_size,
+                    "offset": page * self.page_size,
                 }
             )
-            hits = result.get("itemHits", [])
-            if not hits:
+            items = result.get("message", {}).get("items", [])
+            if not items:
                 break
             reached_cutoff = False
-            for hit in hits:
-                item = hit.get("item", hit)
-                published = self._parse_date(item.get("publishedDate"))
-                if published is None:
-                    logger.warning(f"Skipping chemRxiv item without a valid publishedDate: {item.get('id')}")
+            for item in items:
+                created = self._parse_date(item.get("created", {}).get("date-time"))
+                if created is None:
+                    logger.warning(f"Skipping chemRxiv record without a valid created date: {item.get('DOI')}")
                     continue
-                if published < cutoff:
+                if created < cutoff:
                     reached_cutoff = True
                     break
-                if categories is not None:
-                    item_categories = {c.get("name", "").lower() for c in item.get("categories", [])}
-                    if not item_categories & categories:
-                        continue
+                if not include_new_versions and self._is_new_version(item.get("DOI", "")):
+                    continue
                 collection.append(item)
-            if reached_cutoff or len(hits) < self.page_size:
+            if reached_cutoff or len(items) < self.page_size:
                 break
 
         if len(collection) == 0:
@@ -103,17 +114,32 @@ class ChemrxivRetriever(BaseRetriever):
             collection = collection[:10]
         return collection
 
+    @classmethod
+    def _clean_text(cls, text: str | None) -> str:
+        if not text:
+            return ""
+        text = cls._tag.sub(" ", text)
+        text = html.unescape(text)
+        return re.sub(r"\s+", " ", text).strip()
+
+    @staticmethod
+    def _author_name(author: dict[str, Any]) -> str:
+        if author.get("name"):
+            return author["name"].strip()
+        return f"{author.get('given', '')} {author.get('family', '')}".strip()
+
     def convert_to_paper(self, raw_paper: dict[str, Any]) -> Paper | None:
-        title = raw_paper["title"]
-        authors = [
-            f"{a.get('firstName', '')} {a.get('lastName', '')}".strip()
-            for a in raw_paper.get("authors", [])
-        ]
+        doi = raw_paper["DOI"]
+        titles = raw_paper.get("title") or []
+        title = self._clean_text(titles[0] if titles else "")
+        if not title:
+            return None
+        authors = [self._author_name(a) for a in raw_paper.get("author", [])]
         authors = [a for a in authors if a]
-        abstract = raw_paper.get("abstract", "")
-        url = self.article_url.format(id=raw_paper["id"])
-        pdf_url = (raw_paper.get("asset") or {}).get("original", {}).get("url")
-        full_text = None  # chemRxiv sits behind Cloudflare; do not scrape the PDF
+        abstract = self._clean_text(raw_paper.get("abstract"))
+        url = (raw_paper.get("resource") or {}).get("primary", {}).get("URL") or f"https://doi.org/{doi}"
+        pdf_url = f"https://chemrxiv.org/doi/pdf/{doi}"
+        full_text = None  # chemrxiv.org sits behind Cloudflare; do not scrape the PDF
         return Paper(
             source=self.name,
             title=title,

--- a/src/zotero_arxiv_daily/retriever/chemrxiv_retriever.py
+++ b/src/zotero_arxiv_daily/retriever/chemrxiv_retriever.py
@@ -1,0 +1,125 @@
+from datetime import datetime, timedelta, timezone
+from time import sleep
+from typing import Any
+
+import requests
+from loguru import logger
+
+from .base import BaseRetriever, register_retriever
+from ..protocol import Paper
+
+
+@register_retriever("chemrxiv")
+class ChemrxivRetriever(BaseRetriever):
+    """Retrieve recent preprints from chemRxiv via the Cambridge Open Engage public API.
+
+    chemRxiv publishes preprints continuously rather than in daily batches, so this
+    retriever collects every item published within the last ``lookback_hours`` hours
+    (24 by default) instead of keeping only the latest posting date as the bioRxiv
+    retriever does. Items are fetched newest-first and pagination stops as soon as
+    an item older than the cutoff is seen.
+    """
+
+    api_url = "https://chemrxiv.org/engage/chemrxiv/public-api/v1/items"
+    article_url = "https://chemrxiv.org/engage/chemrxiv/article-details/{id}"
+    page_size = 50  # API maximum
+    max_pages = 20  # safety cap: 1000 items is far more than one day of chemRxiv output
+    lookback_hours = 24
+    request_headers = {
+        "User-Agent": "zotero-arxiv-daily (https://github.com/TideDra/zotero-arxiv-daily)",
+        "Accept": "application/json",
+    }
+
+    def _get_json(self, params: dict[str, Any]) -> dict[str, Any]:
+        retry_num = 10
+        delay_time = 10
+        for i in range(retry_num):
+            try:
+                response = requests.get(
+                    self.api_url,
+                    params=params,
+                    headers=self.request_headers,
+                    timeout=60,
+                )
+                response.raise_for_status()
+                return response.json()
+            except Exception as e:
+                if i == retry_num - 1:
+                    raise e
+                logger.warning(f"Failed to retrieve papers: {str(e)}. Retry in {delay_time} seconds.")
+                sleep(delay_time)
+
+    @staticmethod
+    def _parse_date(value: str | None) -> datetime | None:
+        if not value:
+            return None
+        try:
+            parsed = datetime.fromisoformat(value.replace("Z", "+00:00"))
+        except ValueError:
+            return None
+        if parsed.tzinfo is None:
+            parsed = parsed.replace(tzinfo=timezone.utc)
+        return parsed
+
+    def _retrieve_raw_papers(self) -> list[dict[str, Any]]:
+        cutoff = datetime.now(timezone.utc) - timedelta(hours=self.lookback_hours)
+        categories = self.retriever_config.category
+        if categories is not None:
+            categories = {c.lower() for c in categories}
+
+        collection = []
+        for page in range(self.max_pages):
+            result = self._get_json(
+                {
+                    "limit": self.page_size,
+                    "skip": page * self.page_size,
+                    "sort": "PUBLISHED_DATE_DESC",
+                }
+            )
+            hits = result.get("itemHits", [])
+            if not hits:
+                break
+            reached_cutoff = False
+            for hit in hits:
+                item = hit.get("item", hit)
+                published = self._parse_date(item.get("publishedDate"))
+                if published is None:
+                    logger.warning(f"Skipping chemRxiv item without a valid publishedDate: {item.get('id')}")
+                    continue
+                if published < cutoff:
+                    reached_cutoff = True
+                    break
+                if categories is not None:
+                    item_categories = {c.get("name", "").lower() for c in item.get("categories", [])}
+                    if not item_categories & categories:
+                        continue
+                collection.append(item)
+            if reached_cutoff or len(hits) < self.page_size:
+                break
+
+        if len(collection) == 0:
+            logger.warning(f"No chemRxiv paper found in the last {self.lookback_hours} hours.")
+        if self.config.executor.debug:
+            collection = collection[:10]
+        return collection
+
+    def convert_to_paper(self, raw_paper: dict[str, Any]) -> Paper | None:
+        title = raw_paper["title"]
+        authors = [
+            f"{a.get('firstName', '')} {a.get('lastName', '')}".strip()
+            for a in raw_paper.get("authors", [])
+        ]
+        authors = [a for a in authors if a]
+        abstract = raw_paper.get("abstract", "")
+        url = self.article_url.format(id=raw_paper["id"])
+        pdf_url = (raw_paper.get("asset") or {}).get("original", {}).get("url")
+        full_text = None  # chemRxiv sits behind Cloudflare; do not scrape the PDF
+        return Paper(
+            source=self.name,
+            title=title,
+            authors=authors,
+            abstract=abstract,
+            url=url,
+            pdf_url=pdf_url,
+            full_text=full_text,
+        )

--- a/tests/canned_responses.py
+++ b/tests/canned_responses.py
@@ -232,55 +232,72 @@ SAMPLE_BIORXIV_API_RESPONSE = {
 
 
 # ---------------------------------------------------------------------------
-# chemRxiv canned API response (Cambridge Open Engage public API)
+# chemRxiv canned API response (Crossref REST API, prefix 10.26434)
 # ---------------------------------------------------------------------------
 
-def _chemrxiv_item(item_id, title, published, category, authors, abstract="An abstract."):
+def _chemrxiv_item(doi, title, created, authors, abstract="<jats:p>An abstract.</jats:p>"):
+    """Build a Crossref ``posted-content`` work record for a chemRxiv preprint.
+
+    ``authors`` is a list of (given, family) tuples. ``created`` is an ISO timestamp.
+    """
     return {
-        "item": {
-            "id": item_id,
-            "doi": f"10.26434/chemrxiv-2026-{item_id}",
-            "title": title,
-            "abstract": abstract,
-            "publishedDate": published,
-            "version": "1",
-            "authors": [
-                {"firstName": first, "lastName": last, "institutions": []}
-                for first, last in authors
-            ],
-            "categories": [{"id": f"cat-{category.lower()[:5]}", "name": category}],
-            "asset": {
-                "original": {
-                    "url": f"https://chemrxiv.org/engage/api-gateway/chemrxiv/assets/{item_id}/original/paper.pdf",
-                }
-            },
-        }
+        "DOI": doi,
+        "type": "posted-content",
+        "subtype": "preprint",
+        "publisher": "American Chemical Society (ACS)",
+        "prefix": "10.26434",
+        "title": [title],
+        "abstract": abstract,
+        "created": {"date-time": created, "timestamp": 0},
+        "posted": {"date-parts": [[int(p) for p in created[:10].split("-")]]},
+        "author": [
+            {"given": given, "family": family, "sequence": "first" if i == 0 else "additional",
+             "affiliation": [{"name": "Some University"}]}
+            for i, (given, family) in enumerate(authors)
+        ],
+        "link": [{"URL": f"https://chemrxiv.org/doi/pdf/{doi}", "content-type": "unspecified"}],
+        "resource": {"primary": {"URL": f"https://chemrxiv.org/doi/full/{doi}"}},
+        "URL": f"https://doi.org/{doi}",
     }
 
 
-SAMPLE_CHEMRXIV_API_RESPONSE = {
-    "totalCount": 3,
-    "itemHits": [
-        _chemrxiv_item(
-            "aaa111",
-            "A chemrxiv paper",
-            "2026-03-02T10:00:00.000Z",
-            "Theoretical and Computational Chemistry",
-            [("Jane", "Smith"), ("Alan", "Doe")],
-        ),
-        _chemrxiv_item(
-            "bbb222",
-            "Another chemrxiv paper",
-            "2026-03-02T08:00:00.000Z",
-            "Organic Chemistry",
-            [("Li", "Wang")],
-        ),
-        _chemrxiv_item(
-            "ccc333",
-            "Old chemrxiv paper",
-            "2026-02-20T08:00:00.000Z",
-            "Theoretical and Computational Chemistry",
-            [("Rip", "Old")],
-        ),
-    ],
-}
+def _chemrxiv_response(items, total=None):
+    return {
+        "status": "ok",
+        "message-type": "work-list",
+        "message": {
+            "total-results": len(items) if total is None else total,
+            "items": items,
+            "items-per-page": 100,
+            "query": {"start-index": 0},
+        },
+    }
+
+
+SAMPLE_CHEMRXIV_API_RESPONSE = _chemrxiv_response([
+    _chemrxiv_item(
+        "10.26434/chemrxiv.15007618/v1",
+        "A chemrxiv paper",
+        "2026-03-02T10:00:00Z",
+        [("Jane", "Smith"), ("Alan", "Doe")],
+        abstract="<jats:p>We study RuO<jats:sub>2</jats:sub> &amp; friends.</jats:p>",
+    ),
+    _chemrxiv_item(
+        "10.26434/chemrxiv.15007000/v2",
+        "A revised chemrxiv paper",
+        "2026-03-02T09:00:00Z",
+        [("Li", "Wang")],
+    ),
+    _chemrxiv_item(
+        "10.26434/chemrxiv.15007619/v1",
+        "Another chemrxiv paper",
+        "2026-03-02T08:00:00Z",
+        [("Rip", "Old")],
+    ),
+    _chemrxiv_item(
+        "10.26434/chemrxiv.15006000/v1",
+        "Old chemrxiv paper",
+        "2026-02-20T08:00:00Z",
+        [("Rip", "Old")],
+    ),
+])

--- a/tests/canned_responses.py
+++ b/tests/canned_responses.py
@@ -229,3 +229,58 @@ SAMPLE_BIORXIV_API_RESPONSE = {
         },
     ],
 }
+
+
+# ---------------------------------------------------------------------------
+# chemRxiv canned API response (Cambridge Open Engage public API)
+# ---------------------------------------------------------------------------
+
+def _chemrxiv_item(item_id, title, published, category, authors, abstract="An abstract."):
+    return {
+        "item": {
+            "id": item_id,
+            "doi": f"10.26434/chemrxiv-2026-{item_id}",
+            "title": title,
+            "abstract": abstract,
+            "publishedDate": published,
+            "version": "1",
+            "authors": [
+                {"firstName": first, "lastName": last, "institutions": []}
+                for first, last in authors
+            ],
+            "categories": [{"id": f"cat-{category.lower()[:5]}", "name": category}],
+            "asset": {
+                "original": {
+                    "url": f"https://chemrxiv.org/engage/api-gateway/chemrxiv/assets/{item_id}/original/paper.pdf",
+                }
+            },
+        }
+    }
+
+
+SAMPLE_CHEMRXIV_API_RESPONSE = {
+    "totalCount": 3,
+    "itemHits": [
+        _chemrxiv_item(
+            "aaa111",
+            "A chemrxiv paper",
+            "2026-03-02T10:00:00.000Z",
+            "Theoretical and Computational Chemistry",
+            [("Jane", "Smith"), ("Alan", "Doe")],
+        ),
+        _chemrxiv_item(
+            "bbb222",
+            "Another chemrxiv paper",
+            "2026-03-02T08:00:00.000Z",
+            "Organic Chemistry",
+            [("Li", "Wang")],
+        ),
+        _chemrxiv_item(
+            "ccc333",
+            "Old chemrxiv paper",
+            "2026-02-20T08:00:00.000Z",
+            "Theoretical and Computational Chemistry",
+            [("Rip", "Old")],
+        ),
+    ],
+}

--- a/tests/retriever/test_chemrxiv_retriever.py
+++ b/tests/retriever/test_chemrxiv_retriever.py
@@ -1,0 +1,141 @@
+"""Tests for ChemrxivRetriever."""
+
+from datetime import datetime, timezone
+from types import SimpleNamespace
+
+import pytest
+import requests
+from omegaconf import open_dict
+
+from zotero_arxiv_daily.retriever import get_retriever_cls
+from zotero_arxiv_daily.retriever.chemrxiv_retriever import ChemrxivRetriever
+from tests.canned_responses import SAMPLE_CHEMRXIV_API_RESPONSE, _chemrxiv_item
+
+
+FIXED_NOW = datetime(2026, 3, 2, 12, 0, 0, tzinfo=timezone.utc)
+
+
+class _FixedDatetime(datetime):
+    @classmethod
+    def now(cls, tz=None):
+        return FIXED_NOW if tz is None else FIXED_NOW.astimezone(tz)
+
+
+@pytest.fixture()
+def fixed_now(monkeypatch):
+    monkeypatch.setattr("zotero_arxiv_daily.retriever.chemrxiv_retriever.datetime", _FixedDatetime)
+
+
+def _patch_pages(monkeypatch, pages):
+    """Patch requests.get to serve ``pages`` (list of responses) keyed by ``skip``."""
+    calls = []
+
+    def _patched(url, **kwargs):
+        assert "chemrxiv.org" in url
+        params = kwargs.get("params", {})
+        calls.append(params)
+        skip = int(params.get("skip", 0))
+        limit = int(params.get("limit", 50))
+        page = pages[skip // limit] if skip // limit < len(pages) else {"totalCount": 0, "itemHits": []}
+        resp = SimpleNamespace(status_code=200, raise_for_status=lambda: None)
+        resp.json = lambda: page
+        return resp
+
+    monkeypatch.setattr(requests, "get", _patched)
+    return calls
+
+
+def _configure(config, category):
+    with open_dict(config.source):
+        config.source.chemrxiv = {"category": category}
+    return ChemrxivRetriever(config)
+
+
+def test_chemrxiv_is_registered():
+    assert get_retriever_cls("chemrxiv") is ChemrxivRetriever
+
+
+def test_chemrxiv_retrieve_filters_by_category_and_date(config, monkeypatch, fixed_now):
+    monkeypatch.setattr("zotero_arxiv_daily.retriever.base.sleep", lambda _: None)
+    calls = _patch_pages(monkeypatch, [SAMPLE_CHEMRXIV_API_RESPONSE])
+    retriever = _configure(config, ["theoretical and computational chemistry"])
+    papers = retriever.retrieve_papers()
+    # Old paper is outside 24h window; Organic Chemistry paper is filtered out.
+    assert [p.title for p in papers] == ["A chemrxiv paper"]
+    assert calls[0]["sort"] == "PUBLISHED_DATE_DESC"
+    assert calls[0]["limit"] == 50
+
+
+def test_chemrxiv_null_category_keeps_all_recent(config, monkeypatch, fixed_now):
+    monkeypatch.setattr("zotero_arxiv_daily.retriever.base.sleep", lambda _: None)
+    _patch_pages(monkeypatch, [SAMPLE_CHEMRXIV_API_RESPONSE])
+    retriever = _configure(config, None)
+    papers = retriever.retrieve_papers()
+    assert [p.title for p in papers] == ["A chemrxiv paper", "Another chemrxiv paper"]
+
+
+def test_chemrxiv_paginates_until_cutoff(config, monkeypatch, fixed_now):
+    monkeypatch.setattr(ChemrxivRetriever, "page_size", 2)
+    recent = [
+        _chemrxiv_item(f"id{i}", f"Paper {i}", f"2026-03-02T0{9 - i}:00:00.000Z", "Organic Chemistry", [("A", "B")])
+        for i in range(4)
+    ]
+    old = _chemrxiv_item("old", "Old", "2026-02-01T00:00:00.000Z", "Organic Chemistry", [("A", "B")])
+    pages = [
+        {"totalCount": 5, "itemHits": recent[:2]},
+        {"totalCount": 5, "itemHits": recent[2:]},
+        {"totalCount": 5, "itemHits": [old]},
+        {"totalCount": 5, "itemHits": [old]},  # must never be requested
+    ]
+    calls = _patch_pages(monkeypatch, pages)
+    retriever = _configure(config, None)
+    raw = retriever._retrieve_raw_papers()
+    assert [r["title"] for r in raw] == ["Paper 0", "Paper 1", "Paper 2", "Paper 3"]
+    assert [c["skip"] for c in calls] == [0, 2, 4]
+
+
+def test_chemrxiv_stops_on_short_page(config, monkeypatch, fixed_now):
+    calls = _patch_pages(monkeypatch, [SAMPLE_CHEMRXIV_API_RESPONSE])
+    retriever = _configure(config, None)
+    retriever._retrieve_raw_papers()
+    # Three hits < page_size of 50, so no second request.
+    assert len(calls) == 1
+
+
+def test_chemrxiv_empty_response(config, monkeypatch, fixed_now):
+    monkeypatch.setattr("zotero_arxiv_daily.retriever.base.sleep", lambda _: None)
+    _patch_pages(monkeypatch, [{"totalCount": 0, "itemHits": []}])
+    retriever = _configure(config, ["Organic Chemistry"])
+    assert retriever.retrieve_papers() == []
+
+
+def test_chemrxiv_convert_to_paper(config):
+    retriever = _configure(config, None)
+    raw = SAMPLE_CHEMRXIV_API_RESPONSE["itemHits"][0]["item"]
+    paper = retriever.convert_to_paper(raw)
+    assert paper.source == "chemrxiv"
+    assert paper.title == "A chemrxiv paper"
+    assert paper.authors == ["Jane Smith", "Alan Doe"]
+    assert paper.abstract == "An abstract."
+    assert paper.url == "https://chemrxiv.org/engage/chemrxiv/article-details/aaa111"
+    assert paper.pdf_url.endswith("/aaa111/original/paper.pdf")
+    assert paper.full_text is None
+
+
+def test_chemrxiv_convert_to_paper_without_asset(config):
+    retriever = _configure(config, None)
+    raw = dict(SAMPLE_CHEMRXIV_API_RESPONSE["itemHits"][0]["item"])
+    raw.pop("asset")
+    paper = retriever.convert_to_paper(raw)
+    assert paper.pdf_url is None
+
+
+def test_chemrxiv_debug_truncates(config, monkeypatch, fixed_now):
+    items = [
+        _chemrxiv_item(f"id{i}", f"Paper {i}", "2026-03-02T09:00:00.000Z", "Organic Chemistry", [("A", "B")])
+        for i in range(15)
+    ]
+    _patch_pages(monkeypatch, [{"totalCount": 15, "itemHits": items}])
+    config.executor.debug = True
+    retriever = _configure(config, None)
+    assert len(retriever._retrieve_raw_papers()) == 10

--- a/tests/retriever/test_chemrxiv_retriever.py
+++ b/tests/retriever/test_chemrxiv_retriever.py
@@ -1,4 +1,4 @@
-"""Tests for ChemrxivRetriever."""
+"""Tests for ChemrxivRetriever (Crossref-backed)."""
 
 from datetime import datetime, timezone
 from types import SimpleNamespace
@@ -9,7 +9,11 @@ from omegaconf import open_dict
 
 from zotero_arxiv_daily.retriever import get_retriever_cls
 from zotero_arxiv_daily.retriever.chemrxiv_retriever import ChemrxivRetriever
-from tests.canned_responses import SAMPLE_CHEMRXIV_API_RESPONSE, _chemrxiv_item
+from tests.canned_responses import (
+    SAMPLE_CHEMRXIV_API_RESPONSE,
+    _chemrxiv_item,
+    _chemrxiv_response,
+)
 
 
 FIXED_NOW = datetime(2026, 3, 2, 12, 0, 0, tzinfo=timezone.utc)
@@ -27,16 +31,17 @@ def fixed_now(monkeypatch):
 
 
 def _patch_pages(monkeypatch, pages):
-    """Patch requests.get to serve ``pages`` (list of responses) keyed by ``skip``."""
+    """Patch requests.get to serve ``pages`` (list of Crossref responses) keyed by ``offset``."""
     calls = []
 
     def _patched(url, **kwargs):
-        assert "chemrxiv.org" in url
+        assert "api.crossref.org" in url
         params = kwargs.get("params", {})
         calls.append(params)
-        skip = int(params.get("skip", 0))
-        limit = int(params.get("limit", 50))
-        page = pages[skip // limit] if skip // limit < len(pages) else {"totalCount": 0, "itemHits": []}
+        offset = int(params.get("offset", 0))
+        rows = int(params.get("rows", 100))
+        idx = offset // rows
+        page = pages[idx] if idx < len(pages) else _chemrxiv_response([])
         resp = SimpleNamespace(status_code=200, raise_for_status=lambda: None)
         resp.json = lambda: page
         return resp
@@ -45,9 +50,9 @@ def _patch_pages(monkeypatch, pages):
     return calls
 
 
-def _configure(config, category):
+def _configure(config, include_new_versions=False):
     with open_dict(config.source):
-        config.source.chemrxiv = {"category": category}
+        config.source.chemrxiv = {"include_new_versions": include_new_versions}
     return ChemrxivRetriever(config)
 
 
@@ -55,87 +60,112 @@ def test_chemrxiv_is_registered():
     assert get_retriever_cls("chemrxiv") is ChemrxivRetriever
 
 
-def test_chemrxiv_retrieve_filters_by_category_and_date(config, monkeypatch, fixed_now):
+def test_chemrxiv_retrieve_filters_by_date_and_version(config, monkeypatch, fixed_now):
     monkeypatch.setattr("zotero_arxiv_daily.retriever.base.sleep", lambda _: None)
     calls = _patch_pages(monkeypatch, [SAMPLE_CHEMRXIV_API_RESPONSE])
-    retriever = _configure(config, ["theoretical and computational chemistry"])
+    retriever = _configure(config)
     papers = retriever.retrieve_papers()
-    # Old paper is outside 24h window; Organic Chemistry paper is filtered out.
-    assert [p.title for p in papers] == ["A chemrxiv paper"]
-    assert calls[0]["sort"] == "PUBLISHED_DATE_DESC"
-    assert calls[0]["limit"] == 50
+    # v2 revision dropped; old paper outside 24h window dropped.
+    assert [p.title for p in papers] == ["A chemrxiv paper", "Another chemrxiv paper"]
+    assert calls[0]["sort"] == "created"
+    assert calls[0]["order"] == "desc"
+    assert calls[0]["rows"] == 100
+    assert calls[0]["filter"] == "type:posted-content,from-created-date:2026-03-01"
 
 
-def test_chemrxiv_null_category_keeps_all_recent(config, monkeypatch, fixed_now):
+def test_chemrxiv_include_new_versions(config, monkeypatch, fixed_now):
     monkeypatch.setattr("zotero_arxiv_daily.retriever.base.sleep", lambda _: None)
     _patch_pages(monkeypatch, [SAMPLE_CHEMRXIV_API_RESPONSE])
-    retriever = _configure(config, None)
+    retriever = _configure(config, include_new_versions=True)
     papers = retriever.retrieve_papers()
-    assert [p.title for p in papers] == ["A chemrxiv paper", "Another chemrxiv paper"]
+    assert [p.title for p in papers] == [
+        "A chemrxiv paper",
+        "A revised chemrxiv paper",
+        "Another chemrxiv paper",
+    ]
 
 
 def test_chemrxiv_paginates_until_cutoff(config, monkeypatch, fixed_now):
     monkeypatch.setattr(ChemrxivRetriever, "page_size", 2)
     recent = [
-        _chemrxiv_item(f"id{i}", f"Paper {i}", f"2026-03-02T0{9 - i}:00:00.000Z", "Organic Chemistry", [("A", "B")])
+        _chemrxiv_item(f"10.26434/chemrxiv.{i}/v1", f"Paper {i}", f"2026-03-02T0{9 - i}:00:00Z", [("A", "B")])
         for i in range(4)
     ]
-    old = _chemrxiv_item("old", "Old", "2026-02-01T00:00:00.000Z", "Organic Chemistry", [("A", "B")])
+    old = _chemrxiv_item("10.26434/chemrxiv.old/v1", "Old", "2026-02-01T00:00:00Z", [("A", "B")])
     pages = [
-        {"totalCount": 5, "itemHits": recent[:2]},
-        {"totalCount": 5, "itemHits": recent[2:]},
-        {"totalCount": 5, "itemHits": [old]},
-        {"totalCount": 5, "itemHits": [old]},  # must never be requested
+        _chemrxiv_response(recent[:2], total=5),
+        _chemrxiv_response(recent[2:], total=5),
+        _chemrxiv_response([old], total=5),
+        _chemrxiv_response([old], total=5),  # must never be requested
     ]
     calls = _patch_pages(monkeypatch, pages)
-    retriever = _configure(config, None)
+    retriever = _configure(config)
     raw = retriever._retrieve_raw_papers()
-    assert [r["title"] for r in raw] == ["Paper 0", "Paper 1", "Paper 2", "Paper 3"]
-    assert [c["skip"] for c in calls] == [0, 2, 4]
+    assert [r["title"][0] for r in raw] == ["Paper 0", "Paper 1", "Paper 2", "Paper 3"]
+    assert [c["offset"] for c in calls] == [0, 2, 4]
 
 
 def test_chemrxiv_stops_on_short_page(config, monkeypatch, fixed_now):
     calls = _patch_pages(monkeypatch, [SAMPLE_CHEMRXIV_API_RESPONSE])
-    retriever = _configure(config, None)
+    retriever = _configure(config)
     retriever._retrieve_raw_papers()
-    # Three hits < page_size of 50, so no second request.
     assert len(calls) == 1
 
 
 def test_chemrxiv_empty_response(config, monkeypatch, fixed_now):
     monkeypatch.setattr("zotero_arxiv_daily.retriever.base.sleep", lambda _: None)
-    _patch_pages(monkeypatch, [{"totalCount": 0, "itemHits": []}])
-    retriever = _configure(config, ["Organic Chemistry"])
+    _patch_pages(monkeypatch, [_chemrxiv_response([])])
+    retriever = _configure(config)
     assert retriever.retrieve_papers() == []
 
 
 def test_chemrxiv_convert_to_paper(config):
-    retriever = _configure(config, None)
-    raw = SAMPLE_CHEMRXIV_API_RESPONSE["itemHits"][0]["item"]
+    retriever = _configure(config)
+    raw = SAMPLE_CHEMRXIV_API_RESPONSE["message"]["items"][0]
     paper = retriever.convert_to_paper(raw)
     assert paper.source == "chemrxiv"
     assert paper.title == "A chemrxiv paper"
     assert paper.authors == ["Jane Smith", "Alan Doe"]
-    assert paper.abstract == "An abstract."
-    assert paper.url == "https://chemrxiv.org/engage/chemrxiv/article-details/aaa111"
-    assert paper.pdf_url.endswith("/aaa111/original/paper.pdf")
+    # JATS tags stripped, entities unescaped, whitespace collapsed
+    assert paper.abstract == "We study RuO 2 & friends."
+    assert paper.url == "https://chemrxiv.org/doi/full/10.26434/chemrxiv.15007618/v1"
+    assert paper.pdf_url == "https://chemrxiv.org/doi/pdf/10.26434/chemrxiv.15007618/v1"
     assert paper.full_text is None
 
 
-def test_chemrxiv_convert_to_paper_without_asset(config):
-    retriever = _configure(config, None)
-    raw = dict(SAMPLE_CHEMRXIV_API_RESPONSE["itemHits"][0]["item"])
-    raw.pop("asset")
+def test_chemrxiv_convert_to_paper_fallbacks(config):
+    retriever = _configure(config)
+    raw = dict(SAMPLE_CHEMRXIV_API_RESPONSE["message"]["items"][0])
+    raw.pop("resource")
+    raw.pop("abstract")
+    raw["author"] = [{"name": "Some Consortium"}, {"given": "Only", "family": "Person"}]
     paper = retriever.convert_to_paper(raw)
-    assert paper.pdf_url is None
+    assert paper.url == "https://doi.org/10.26434/chemrxiv.15007618/v1"
+    assert paper.abstract == ""
+    assert paper.authors == ["Some Consortium", "Only Person"]
+
+
+def test_chemrxiv_convert_to_paper_without_title_is_skipped(config):
+    retriever = _configure(config)
+    raw = dict(SAMPLE_CHEMRXIV_API_RESPONSE["message"]["items"][0])
+    raw["title"] = []
+    assert retriever.convert_to_paper(raw) is None
+
+
+def test_chemrxiv_version_detection(config):
+    retriever = _configure(config)
+    assert not retriever._is_new_version("10.26434/chemrxiv.15007618/v1")
+    assert retriever._is_new_version("10.26434/chemrxiv.15007618/v2")
+    assert retriever._is_new_version("10.26434/chemrxiv-2023-abcde-v3")
+    assert not retriever._is_new_version("10.26434/chemrxiv-2023-abcde")
 
 
 def test_chemrxiv_debug_truncates(config, monkeypatch, fixed_now):
     items = [
-        _chemrxiv_item(f"id{i}", f"Paper {i}", "2026-03-02T09:00:00.000Z", "Organic Chemistry", [("A", "B")])
+        _chemrxiv_item(f"10.26434/chemrxiv.{i}/v1", f"Paper {i}", "2026-03-02T09:00:00Z", [("A", "B")])
         for i in range(15)
     ]
-    _patch_pages(monkeypatch, [{"totalCount": 15, "itemHits": items}])
+    _patch_pages(monkeypatch, [_chemrxiv_response(items)])
     config.executor.debug = True
-    retriever = _configure(config, None)
+    retriever = _configure(config)
     assert len(retriever._retrieve_raw_papers()) == 10


### PR DESCRIPTION
## Summary

Adds **chemRxiv** as a paper source alongside arXiv, bioRxiv and medRxiv.

- New `chemrxiv` retriever (`src/zotero_arxiv_daily/retriever/chemrxiv_retriever.py`), registered via `@register_retriever("chemrxiv")`.
- Data comes from the **Crossref REST API** (`https://api.crossref.org/prefixes/10.26434/works`). chemRxiv moved from Cambridge Open Engage to Wiley's Research Exchange platform on 2026-01-21; the old `public-api/v1/items` endpoint now returns 404 and the new chemrxiv.org sits behind Cloudflare bot protection, while every chemRxiv preprint is registered with Crossref within minutes of posting with title, JATS abstract, authors + affiliations, posted/created dates and `chemrxiv.org/doi/full|pdf/...` links.
- chemRxiv publishes continuously rather than in daily batches, so the retriever pages newest-first (`sort=created&order=desc`) and keeps every record created in the last 24 h, instead of the bioRxiv "latest date only" approach.
- Crossref does not expose chemRxiv subject categories, so there is no `category` option; chemRxiv volume is only ~30-40 preprints/day and the reranker does the selection. Revised versions (`.../v2`, `.../v3`) are skipped unless `source.chemrxiv.include_new_versions: true` (they are ~1/3 of daily records).
- JATS markup in abstracts is stripped; `full_text` is left `None` (same as bioRxiv) since chemrxiv.org blocks scraping.
- Config/docs: `source.chemrxiv.include_new_versions` in `config/base.yaml`, README, CLAUDE.md.

## Config

```yaml
source:
  chemrxiv:
    include_new_versions: false
executor:
  source: ['arxiv', 'chemrxiv']
```

## Test plan

- [x] `uv run pytest` (11 new tests in `tests/retriever/test_chemrxiv_retriever.py`: registration, 24 h window + version filtering, pagination stop at cutoff, short-page stop, empty response, `convert_to_paper` incl. JATS stripping / org authors / missing resource URL, debug truncation)
- [x] Live run against Crossref: 27 first-posting preprints in the last 24 h (41 incl. revisions), correct titles/authors/abstracts/links
- [x] Full local pipeline with `executor.source=[chemrxiv]`: Zotero corpus -> retrieve -> local reranker -> TLDR -> email
- [x] GitHub Actions "Test" workflow on this branch with `source: ['arxiv','chemrxiv']`: email received

🤖 Generated with [Claude Code](https://claude.com/claude-code)
